### PR TITLE
Fix for Python 3.8.17 using macOs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "esptool",
         "nest_asyncio",
         "pylsl==1.10.5",
+        'scipy'
         'pypiwin32 ; platform_system=="Windows"',
         'kivy.deps.glew ; platform_system=="Windows"',
         'kivy.deps.sdl2 ; platform_system=="Windows"',

--- a/uvicmuse/MuseBLE.py
+++ b/uvicmuse/MuseBLE.py
@@ -254,7 +254,7 @@ class MuseBLE(object):
     # Handlers
     def _handle_control(self, sender, packet):
         # Handles the message coming from the control sequence
-        assert sender == 13, "_handle_control is receiving a message " \
+        assert sender.handle == 13, "_handle_control is receiving a message " \
                              "with a different UUID " + str(sender)
 
         bit_decoder = bitstring.Bits(bytes=packet)
@@ -275,7 +275,7 @@ class MuseBLE(object):
             self._init_sample_control()
 
     def _handle_eeg(self, sender, packet):
-        index = int((sender - 31) / 3)
+        index = int((sender.handle - 31) / 3)
         timestamp = time()
         tm, d = self._unpack_eeg_channel(packet)
         # Logger.info('this is what eeg received: ' + str(sender) + 'data: ' + str(d))
@@ -286,7 +286,7 @@ class MuseBLE(object):
         self.timestamps_eeg[index] = timestamp
 
         # Check if this is the last data in the sequence
-        if sender == 34:
+        if sender.handle == 34:
             if tm != self.last_tm_eeg + 1:
                 pass
                 # print("Missing sample %d : %d" % (tm, self.last_tm_eeg))

--- a/uvicmuse/MuseFinder.py
+++ b/uvicmuse/MuseFinder.py
@@ -17,7 +17,7 @@ class MuseFinder(object):
             # search for muses timeout/2 times, 2 seconds each time
             devices = await discover(timeout=2)
             for d in devices:
-                if MUSE_NAME in d.name and not self._is_already_found(newly_found_muse=d):
+                if d.name is not None and MUSE_NAME in d.name and not self._is_already_found(newly_found_muse=d):
                     self.muses.append(d)
                     if self.add_muse_to_list_callback is not None:
                         self.add_muse_to_list_callback(d)


### PR DESCRIPTION
I was trying to run the project and I found some errors while trying to run it with python 3.8.17 in macOs.

1. On running it said the module scipy was not found, I added it to the dependencies.
2. sender seems to be an object `BleakGATTCharacteristicCoreBluetooth` now, which failed in multiple places. Now we require to obtain the attribute handle from this object instead of the sender itself.
3. In the search of Bluetooth devices, when the name is None the search itself failed, fixed it.